### PR TITLE
Adding new vendor mac address prefix for flipper zero detection

### DIFF
--- a/VScode Platformio/src/flipperzero_detector.cpp
+++ b/VScode Platformio/src/flipperzero_detector.cpp
@@ -29,7 +29,7 @@ static std::vector<FlipperZeroDeviceData> flipperZeroDevices;
 const int MAX_DEVICES = 100;
 const String FLIPPERZERO_MAC_PREFIX_1 = "80:e1:26";
 const String FLIPPERZERO_MAC_PREFIX_2 = "80:e1:27";
-const String FLIPPERZERO_MAC_PREFIX_2 = "0C:FA:22";
+const String FLIPPERZERO_MAC_PREFIX_3 = "0C:FA:22";
 
 int currentIndex = 0;
 int listStartIndex = 0;

--- a/VScode Platformio/src/flipperzero_detector.cpp
+++ b/VScode Platformio/src/flipperzero_detector.cpp
@@ -29,6 +29,7 @@ static std::vector<FlipperZeroDeviceData> flipperZeroDevices;
 const int MAX_DEVICES = 100;
 const String FLIPPERZERO_MAC_PREFIX_1 = "80:e1:26";
 const String FLIPPERZERO_MAC_PREFIX_2 = "80:e1:27";
+const String FLIPPERZERO_MAC_PREFIX_2 = "0C:FA:22";
 
 int currentIndex = 0;
 int listStartIndex = 0;
@@ -60,7 +61,8 @@ class MyFlipperAdvertisedDeviceCallbacks : public BLEAdvertisedDeviceCallbacks {
 
     String macAddress = String(deviceAddress);
     bool isFlipperZero = macAddress.startsWith(FLIPPERZERO_MAC_PREFIX_1) ||
-                     macAddress.startsWith(FLIPPERZERO_MAC_PREFIX_2);
+                     macAddress.startsWith(FLIPPERZERO_MAC_PREFIX_2) ||
+                     macAddress.startsWith(FLIPPERZERO_MAC_PREFIX_3);
 
     for (auto &dev : flipperZeroDevices) {
       if (strcmp(dev.address, deviceAddress) == 0) {


### PR DESCRIPTION
Adding new vendor mac address prefix for flipper zero detection based on : 


source: 
https://x.com/flipper_zero/status/1839389596200886404?lang=fr

https://udger.com/resources/mac-address-vendor-detail?name=flipper_devices_inc