### PR TITLE
fix build errors from missing pindefs in axon, and cardskimmer

### DIFF
--- a/VScode Platformio/include/axon_detector.h
+++ b/VScode Platformio/include/axon_detector.h
@@ -11,6 +11,7 @@
 #include <Arduino.h>
 #include <U8g2lib.h>
 #include "config.h"
+#include "pindefs.h"
 
 void axonDetectorSetup();
 void axonDetectorLoop();

--- a/VScode Platformio/include/cardskimmer_detector.h
+++ b/VScode Platformio/include/cardskimmer_detector.h
@@ -11,6 +11,7 @@
 #include <Arduino.h>
 #include <U8g2lib.h>
 #include "config.h"
+#include "pindefs.h"
 
 void cardskimmerDetectorSetup();
 void cardskimmerDetectorLoop();


### PR DESCRIPTION
axon and cardskimmer were both missing the pindefs within the given header files leading to build failures

<img width="885" height="555" alt="image" src="https://github.com/user-attachments/assets/15a0e6f4-78dc-448a-ab2b-8e52de4ea401" />
