### PR TITLE
fix beacon spam frame construction + add packet logger tool

### DIFF
--- a/VScode Platformio/include/packet_logger.h
+++ b/VScode Platformio/include/packet_logger.h
@@ -1,0 +1,22 @@
+/*
+    nyanBOX by Nyan Devices
+    https://github.com/jbohack/nyanBOX
+    Copyright (c) 2026 jbohack
+
+    Licensed under the MIT License
+    https://opensource.org/licenses/MIT
+
+    SPDX-License-Identifier: MIT
+*/
+
+#ifndef PACKET_LOGGER_H
+#define PACKET_LOGGER_H
+
+#include "esp_wifi.h"
+#include "pindefs.h"
+#include <U8g2lib.h>
+
+void packetLoggerSetup();
+void packetLoggerLoop();
+
+#endif

--- a/VScode Platformio/src/beacon_spam.cpp
+++ b/VScode Platformio/src/beacon_spam.cpp
@@ -93,62 +93,68 @@ const char ssids[] PROGMEM = {
   "Lan Of The Lost\n"
 };
 
-char emptySSID[32];
 uint8_t macAddr[6];
 uint8_t wifi_channel = 1;
 uint32_t currentTime = 0;
 
-uint8_t beaconPacketOpen[83] = {
-  0x80, 0x00, 0x00, 0x00,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
-  0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
-  0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x64, 0x00,
-  0x01, 0x04,
-  0x00, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x0c, 0x18, 0x30, 0x48,
-  0x03, 0x01, 0x01
-};
-
-uint8_t beaconPacketWPA2[109] = {
-  0x80, 0x00, 0x00, 0x00,
-  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-  0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
-  0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
-  0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x64, 0x00,
-  0x11, 0x04,
-  0x00, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
-  0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x0c, 0x18, 0x30, 0x48,
-  0x03, 0x01, 0x01,
-  0x30, 0x18, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x02,
-  0x02, 0x00, 0x00, 0x0f, 0xac, 0x04, 0x00, 0x0f,
-  0xac, 0x02, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x02,
-  0x00, 0x00
-};
-
 void randomMac() {
-  for (int i = 0; i < 6; i++) {
-    macAddr[i] = random(256);
-  }
+  for (int i = 0; i < 6; i++) macAddr[i] = random(256);
   macAddr[0] |= 0x02;
   macAddr[0] &= 0xFE;
 }
 
-uint16_t randomBeaconInterval() {
-  uint16_t intervals[] = {0x64, 0x32, 0xC8, 0x12C};
-  return intervals[random(4)] | (intervals[random(4)] << 8);
+// Build beacon frame dynamically so IE tags are at the correct offsets
+// regardless of SSID length. The old static templates had tags at fixed
+// positions which broke when the SSID was shorter than 32 bytes.
+void sendBeaconFrame(const char *ssid, uint8_t ssidLen, uint8_t channel, bool wpa2) {
+  uint8_t frame[128];
+  memset(frame, 0, sizeof(frame));
+  int p = 0;
+
+  frame[p++] = 0x80; frame[p++] = 0x00;
+  frame[p++] = 0x00; frame[p++] = 0x00;
+  memset(&frame[p], 0xFF, 6); p += 6;
+  randomMac();
+  memcpy(&frame[p], macAddr, 6); p += 6;
+  memcpy(&frame[p], macAddr, 6); p += 6;
+  uint16_t seq = random(4096) << 4;
+  frame[p++] = seq & 0xFF;
+  frame[p++] = (seq >> 8) & 0xFF;
+
+  uint64_t ts = (uint64_t)esp_timer_get_time();
+  memcpy(&frame[p], &ts, 8); p += 8;
+  frame[p++] = 0x64; frame[p++] = 0x00;
+  frame[p++] = wpa2 ? 0x11 : 0x01;
+  frame[p++] = 0x04;
+
+  // SSID
+  frame[p++] = 0x00;
+  frame[p++] = ssidLen;
+  memcpy(&frame[p], ssid, ssidLen); p += ssidLen;
+
+  // Supported Rates
+  frame[p++] = 0x01; frame[p++] = 0x08;
+  frame[p++] = 0x82; frame[p++] = 0x84;
+  frame[p++] = 0x8b; frame[p++] = 0x96;
+  frame[p++] = 0x0c; frame[p++] = 0x18;
+  frame[p++] = 0x30; frame[p++] = 0x48;
+
+  // DS Parameter Set
+  frame[p++] = 0x03; frame[p++] = 0x01; frame[p++] = channel;
+
+  // RSN (WPA2)
+  if (wpa2) {
+    const uint8_t rsn[] = {
+      0x30, 0x18, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x02,
+      0x02, 0x00, 0x00, 0x0f, 0xac, 0x04, 0x00, 0x0f,
+      0xac, 0x02, 0x01, 0x00, 0x00, 0x0f, 0xac, 0x02,
+      0x00, 0x00
+    };
+    memcpy(&frame[p], rsn, sizeof(rsn)); p += sizeof(rsn);
+  }
+
+  esp_wifi_set_channel(channel, WIFI_SECOND_CHAN_NONE);
+  esp_wifi_80211_tx(WIFI_IF_AP, frame, p, false);
 }
 
 void nextChannel() {
@@ -349,7 +355,7 @@ void updateSSIDScan() {
     if (now - beacon_scanStartTime > SCAN_DURATION) {
         processScanResults(now);
         esp_wifi_scan_stop();
-        esp_wifi_set_promiscuous(true);
+        esp_wifi_set_mode(WIFI_MODE_AP);
 
         beacon_isScanning = false;
         beacon_lastScanTime = now;
@@ -365,15 +371,13 @@ void updateSSIDScan() {
 }
 
 void beaconSpamSetup() {
-  for (int i = 0; i < 32; i++) emptySSID[i] = ' ';
   randomSeed((uint32_t)esp_random());
 
   beacon_isScanning = false;
   beacon_lastApCount = 0;
 
-  initWiFi(WIFI_MODE_STA);
+  initWiFi(WIFI_MODE_AP);
 
-  esp_wifi_set_promiscuous(true);
   esp_wifi_set_channel(channels[0], WIFI_SECOND_CHAN_NONE);
 
   pinMode(BTN_UP, INPUT_PULLUP);
@@ -488,32 +492,7 @@ void beaconSpamLoop() {
       }
 
       for (const auto& entry : scannedSSIDs) {
-        bool useWPA2 = (random(10) < 4);
-        uint8_t *packet = useWPA2 ? beaconPacketWPA2 : beaconPacketOpen;
-        size_t packetSize = useWPA2 ? sizeof(beaconPacketWPA2) : sizeof(beaconPacketOpen);
-        
-        randomMac();
-        memcpy(&packet[10], macAddr, 6);
-        memcpy(&packet[16], macAddr, 6);
-        
-        uint16_t seqNum = random(4096) << 4;
-        packet[22] = seqNum & 0xFF;
-        packet[23] = (seqNum >> 8) & 0xFF;
-        
-        memset(&packet[38], ' ', 32);
-        size_t len = strlen(entry.ssid);
-        memcpy(&packet[38], entry.ssid, len);
-        packet[37] = len;
-        
-        uint16_t beaconInt = randomBeaconInterval();
-        packet[32] = beaconInt & 0xFF;
-        packet[33] = (beaconInt >> 8) & 0xFF;
-        
-        packet[82] = entry.channel;
-        uint64_t timestamp = (uint64_t)esp_timer_get_time();
-        memcpy(&packet[24], &timestamp, 8);
-        esp_wifi_set_channel(entry.channel, WIFI_SECOND_CHAN_NONE);
-        esp_wifi_80211_tx(WIFI_IF_STA, packet, packetSize, false);
+        sendBeaconFrame(entry.ssid, strlen(entry.ssid), entry.channel, random(10) < 4);
         delayMicroseconds(100);
       }
       if (left) {
@@ -568,32 +547,7 @@ void beaconSpamLoop() {
           if (currentTime - lastBeacon > beaconInterval) {
             for (const auto& entry : scannedSSIDs) {
               if (entry.selected) {
-                bool useWPA2 = (random(10) < 4);
-                uint8_t *packet = useWPA2 ? beaconPacketWPA2 : beaconPacketOpen;
-                size_t packetSize = useWPA2 ? sizeof(beaconPacketWPA2) : sizeof(beaconPacketOpen);
-                
-                randomMac();
-                memcpy(&packet[10], macAddr, 6);
-                memcpy(&packet[16], macAddr, 6);
-                
-                uint16_t seqNum = random(4096) << 4;
-                packet[22] = seqNum & 0xFF;
-                packet[23] = (seqNum >> 8) & 0xFF;
-                
-                memset(&packet[38], ' ', 32);
-                size_t len = strlen(entry.ssid);
-                memcpy(&packet[38], entry.ssid, len);
-                packet[37] = len;
-                
-                uint16_t beaconInt = randomBeaconInterval();
-                packet[32] = beaconInt & 0xFF;
-                packet[33] = (beaconInt >> 8) & 0xFF;
-                
-                packet[82] = entry.channel;
-                uint64_t timestamp = (uint64_t)esp_timer_get_time();
-                memcpy(&packet[24], &timestamp, 8);
-                esp_wifi_set_channel(entry.channel, WIFI_SECOND_CHAN_NONE);
-                esp_wifi_80211_tx(WIFI_IF_STA, packet, packetSize, false);
+                sendBeaconFrame(entry.ssid, strlen(entry.ssid), entry.channel, random(10) < 4);
                 delayMicroseconds(100);
               }
             }
@@ -664,33 +618,14 @@ void beaconSpamLoop() {
             } while (tmp != '\n' && j <= 32 && (ssidStart + j) < (int)strlen_P(ssids));
             
             uint8_t ssidLen = j - 1;
-            
-            bool useWPA2 = (random(10) < 4);
-            uint8_t *packet = useWPA2 ? beaconPacketWPA2 : beaconPacketOpen;
-            size_t packetSize = useWPA2 ? sizeof(beaconPacketWPA2) : sizeof(beaconPacketOpen);
-            
-            randomMac();
-            memcpy(&packet[10], macAddr, 6);
-            memcpy(&packet[16], macAddr, 6);
-            
-            uint16_t seqNum = random(4096) << 4;
-            packet[22] = seqNum & 0xFF;
-            packet[23] = (seqNum >> 8) & 0xFF;
-            
-            memcpy(&packet[38], emptySSID, 32);
-            for (int k = 0; k < ssidLen; k++) {
-              packet[38 + k] = pgm_read_byte(ssids + ssidStart + k);
+
+            char ssidBuf[33];
+            for (int k = 0; k < ssidLen && k < 32; k++) {
+              ssidBuf[k] = pgm_read_byte(ssids + ssidStart + k);
             }
-            packet[37] = ssidLen;
-            
-            uint16_t beaconInt = randomBeaconInterval();
-            packet[32] = beaconInt & 0xFF;
-            packet[33] = (beaconInt >> 8) & 0xFF;
-            
-            packet[82] = wifi_channel;
-            uint64_t timestamp = (uint64_t)esp_timer_get_time();
-            memcpy(&packet[24], &timestamp, 8);
-            esp_wifi_80211_tx(WIFI_IF_STA, packet, packetSize, false);
+            ssidBuf[ssidLen] = '\0';
+
+            sendBeaconFrame(ssidBuf, ssidLen, wifi_channel, random(10) < 4);
           }
           batchBeacon++;
         }
@@ -737,33 +672,8 @@ void beaconSpamLoop() {
               randomSSID[i] = chars[random(strlen(chars))];
             }
             randomSSID[length] = '\0';
-            
-            bool useWPA2 = (random(10) < 4);
-            uint8_t *packet = useWPA2 ? beaconPacketWPA2 : beaconPacketOpen;
-            size_t packetSize = useWPA2 ? sizeof(beaconPacketWPA2) : sizeof(beaconPacketOpen);
-            
-            randomMac();
-            memcpy(&packet[10], macAddr, 6);
-            memcpy(&packet[16], macAddr, 6);
-            
-            uint16_t seqNum = random(4096) << 4;
-            packet[22] = seqNum & 0xFF;
-            packet[23] = (seqNum >> 8) & 0xFF;
-            
-            memset(&packet[38], ' ', 32);
-            uint8_t len = length;
-            if (len > 32) len = 32;
-            memcpy(&packet[38], randomSSID, len);
-            packet[37] = len;
-            
-            uint16_t beaconInt = randomBeaconInterval();
-            packet[32] = beaconInt & 0xFF;
-            packet[33] = (beaconInt >> 8) & 0xFF;
-            
-            packet[82] = wifi_channel;
-            uint64_t timestamp = (uint64_t)esp_timer_get_time();
-            memcpy(&packet[24], &timestamp, 8);
-            esp_wifi_80211_tx(WIFI_IF_STA, packet, packetSize, false);
+
+            sendBeaconFrame(randomSSID, length, wifi_channel, random(10) < 4);
           }
           
           if (++randomBatchesSinceSwitch >= 4) {

--- a/VScode Platformio/src/nyanBOX.ino
+++ b/VScode Platformio/src/nyanBOX.ino
@@ -69,6 +69,7 @@
 #include "../include/display_mirror.h"
 #include "../include/password.h"
 #include "../include/radio_manager.h"
+#include "../include/packet_logger.h"
 
 RF24 radios[] = {
   RF24(RADIO_CE_PIN_1, RADIO_CSN_PIN_1),
@@ -409,6 +410,7 @@ MenuItem otherMenu[] = {
   { "Device Scout", nullptr, deviceScoutSetup, deviceScoutLoop, cleanupDeviceScout },
   { "Scanner",      nullptr, scannerSetup,    scannerLoop,    cleanupRadio },
   { "Analyzer",     nullptr, analyzerSetup,   analyzerLoop,   cleanupRadio },
+  { "Packet Logger", nullptr, packetLoggerSetup, packetLoggerLoop, cleanupWiFi },
   { "Setting",      nullptr, settingSetup,    settingLoop,    noCleanup },
   { "About",        nullptr, aboutSetup,      aboutLoop,      aboutCleanup },
   { "Back",         nullptr, nullptr,         nullptr,        noCleanup }

--- a/VScode Platformio/src/packet_logger.cpp
+++ b/VScode Platformio/src/packet_logger.cpp
@@ -1,0 +1,333 @@
+/*
+    nyanBOX by Nyan Devices
+    https://github.com/jbohack/nyanBOX
+    Copyright (c) 2026 jbohack
+
+    Licensed under the MIT License
+    https://opensource.org/licenses/MIT
+
+    SPDX-License-Identifier: MIT
+*/
+
+#include "../include/packet_logger.h"
+#include "../include/radio_manager.h"
+#include "../include/sleep_manager.h"
+#include "../include/display_mirror.h"
+#include "../include/setting.h"
+#include "esp_wifi.h"
+#include <string.h>
+
+extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C u8g2;
+
+namespace {
+
+struct PacketEntry {
+    unsigned long timestamp;
+    uint8_t channel;
+    uint8_t frameType;
+    uint8_t frameSubtype;
+    uint8_t srcMAC[6];
+    uint8_t dstMAC[6];
+    uint8_t bssid[6];
+    int8_t  rssi;
+    uint16_t length;
+};
+
+const int RING_SIZE = 20;
+PacketEntry ring[RING_SIZE];
+volatile int ringHead = 0;
+volatile uint32_t totalPackets = 0;
+volatile uint32_t mgmtCount = 0;
+volatile uint32_t dataCount = 0;
+
+uint8_t currentChannel = 1;
+bool autoHop = true;
+bool paused = false;
+unsigned long lastHop = 0;
+unsigned long lastDraw = 0;
+
+const unsigned long HOP_INTERVAL = 500;
+const unsigned long DRAW_INTERVAL = 200;
+
+static bool needsRedraw = true;
+static uint32_t lastDisplayedTotal = 0;
+static uint8_t lastDisplayedChannel = 0;
+static bool lastPaused = false;
+
+const char* subtypeShort(uint8_t type, uint8_t subtype) {
+    if (type == 0) {
+        switch (subtype) {
+            case 0:  return "AQ";
+            case 1:  return "AR";
+            case 4:  return "PQ";
+            case 5:  return "PR";
+            case 8:  return "Bc";
+            case 10: return "Di";
+            case 11: return "Au";
+            case 12: return "DA";
+            case 13: return "Ac";
+            default: return "M?";
+        }
+    } else if (type == 1) {
+        switch (subtype) {
+            case 9:  return "Bk";
+            case 11: return "RT";
+            case 12: return "CT";
+            case 13: return "Ak";
+            default: return "C?";
+        }
+    } else if (type == 2) {
+        switch (subtype) {
+            case 0:  return "Dt";
+            case 4:  return "Nl";
+            case 8:  return "QD";
+            case 12: return "QN";
+            default: return "D?";
+        }
+    }
+    return "??";
+}
+
+const char* subtypeName(uint8_t type, uint8_t subtype) {
+    if (type == 0) {
+        switch (subtype) {
+            case 0:  return "AssocReq";
+            case 1:  return "AssocResp";
+            case 4:  return "ProbeReq";
+            case 5:  return "ProbeResp";
+            case 8:  return "Beacon";
+            case 10: return "Disassoc";
+            case 11: return "Auth";
+            case 12: return "Deauth";
+            case 13: return "Action";
+            default: return "MgmtOther";
+        }
+    } else if (type == 1) {
+        switch (subtype) {
+            case 9:  return "BlockAck";
+            case 11: return "RTS";
+            case 12: return "CTS";
+            case 13: return "ACK";
+            default: return "CtrlOther";
+        }
+    } else if (type == 2) {
+        switch (subtype) {
+            case 0:  return "Data";
+            case 4:  return "Null";
+            case 8:  return "QoSData";
+            case 12: return "QoSNull";
+            default: return "DataOther";
+        }
+    }
+    return "Unknown";
+}
+
+const char* typeName(uint8_t type) {
+    switch (type) {
+        case 0: return "MGMT";
+        case 1: return "CTRL";
+        case 2: return "DATA";
+        default: return "UNK";
+    }
+}
+
+void macStr(const uint8_t *mac, char *buf) {
+    snprintf(buf, 18, "%02X:%02X:%02X:%02X:%02X:%02X",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+void macShort(const uint8_t *mac, char *buf) {
+    snprintf(buf, 9, "%02X%02X%02X", mac[3], mac[4], mac[5]);
+}
+
+void IRAM_ATTR packetSniffer(void *buf, wifi_promiscuous_pkt_type_t type) {
+    if (paused) return;
+
+    const wifi_promiscuous_pkt_t *pkt = (wifi_promiscuous_pkt_t *)buf;
+    const uint8_t *frame = pkt->payload;
+    uint16_t len = pkt->rx_ctrl.sig_len;
+    if (len < 24) return;
+
+    uint8_t fc0 = frame[0];
+    uint8_t ftype = (fc0 >> 2) & 0x03;
+    uint8_t fsubtype = (fc0 >> 4) & 0x0F;
+
+    PacketEntry entry;
+    entry.timestamp = millis();
+    entry.channel = currentChannel;
+    entry.frameType = ftype;
+    entry.frameSubtype = fsubtype;
+    entry.rssi = pkt->rx_ctrl.rssi;
+    entry.length = len;
+    memcpy(entry.dstMAC, &frame[4], 6);
+    memcpy(entry.srcMAC, &frame[10], 6);
+    memcpy(entry.bssid, &frame[16], 6);
+
+    ring[ringHead] = entry;
+    ringHead = (ringHead + 1) % RING_SIZE;
+    totalPackets++;
+
+    if (ftype == 0) mgmtCount++;
+    else if (ftype == 2) dataCount++;
+
+    char src[18], dst[18], bss[18];
+    macStr(entry.srcMAC, src);
+    macStr(entry.dstMAC, dst);
+    macStr(entry.bssid, bss);
+
+    Serial.printf("%lu,%u,%s,%s,%s,%s,%s,%d,%u\n",
+        entry.timestamp, entry.channel,
+        typeName(ftype), subtypeName(ftype, fsubtype),
+        src, dst, bss, entry.rssi, len);
+}
+
+void drawScreen() {
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_5x8_tr);
+
+    char header[32];
+    if (paused) {
+        snprintf(header, sizeof(header), "PAUSED  Ch:%02d #%lu", currentChannel, (unsigned long)totalPackets);
+    } else if (autoHop) {
+        snprintf(header, sizeof(header), "Pkt Log Ch:%02d #%lu", currentChannel, (unsigned long)totalPackets);
+    } else {
+        snprintf(header, sizeof(header), "LOCKED  Ch:%02d #%lu", currentChannel, (unsigned long)totalPackets);
+    }
+    u8g2.drawStr(0, 8, header);
+    u8g2.drawHLine(0, 10, 128);
+
+    for (int i = 0; i < 5; i++) {
+        int idx = (ringHead - 1 - i + RING_SIZE) % RING_SIZE;
+        if (ring[idx].timestamp == 0) continue;
+
+        const PacketEntry &e = ring[idx];
+        char srcShort[9];
+        if (privacyModeEnabled) {
+            snprintf(srcShort, sizeof(srcShort), "XX:XX:XX");
+        } else {
+            macShort(e.srcMAC, srcShort);
+        }
+
+        char line[28];
+        snprintf(line, sizeof(line), "%-2s %s %3d %4u",
+                 subtypeShort(e.frameType, e.frameSubtype),
+                 srcShort, e.rssi, e.length);
+        u8g2.drawStr(0, 20 + (i * 8), line);
+    }
+
+    if (paused) {
+        char stats[32];
+        snprintf(stats, sizeof(stats), "M:%lu D:%lu",
+                 (unsigned long)mgmtCount, (unsigned long)dataCount);
+        u8g2.drawStr(0, 62, stats);
+    } else {
+        u8g2.drawStr(0, 62, "U/D=Ch R=Pause L=Back");
+    }
+
+    u8g2.sendBuffer();
+    displayMirrorSend(u8g2);
+}
+
+}
+
+void packetLoggerSetup() {
+    memset(ring, 0, sizeof(ring));
+    ringHead = 0;
+    totalPackets = 0;
+    mgmtCount = 0;
+    dataCount = 0;
+    currentChannel = 1;
+    autoHop = true;
+    paused = false;
+    lastHop = 0;
+    lastDraw = 0;
+    needsRedraw = true;
+    lastDisplayedTotal = 0;
+    lastDisplayedChannel = 0;
+    lastPaused = false;
+
+    initWiFi(WIFI_MODE_STA);
+
+    wifi_promiscuous_filter_t filter;
+    filter.filter_mask = WIFI_PROMIS_FILTER_MASK_MGMT | WIFI_PROMIS_FILTER_MASK_DATA;
+    esp_wifi_set_promiscuous_filter(&filter);
+    esp_wifi_set_promiscuous_rx_cb(packetSniffer);
+    esp_wifi_set_promiscuous(true);
+    esp_wifi_set_channel(currentChannel, WIFI_SECOND_CHAN_NONE);
+
+    Serial.println();
+    Serial.println("# nyanBOX Packet Logger v1.0");
+    Serial.println("# timestamp_ms,channel,type,subtype,src_mac,dst_mac,bssid,rssi_dbm,length");
+
+    pinMode(BUTTON_PIN_UP, INPUT_PULLUP);
+    pinMode(BUTTON_PIN_DOWN, INPUT_PULLUP);
+    pinMode(BUTTON_PIN_LEFT, INPUT_PULLUP);
+    pinMode(BUTTON_PIN_RIGHT, INPUT_PULLUP);
+
+    drawScreen();
+}
+
+void packetLoggerLoop() {
+    unsigned long now = millis();
+
+    static bool upPrev = false, downPrev = false, rightPrev = false;
+    bool upNow = digitalRead(BUTTON_PIN_UP) == LOW;
+    bool downNow = digitalRead(BUTTON_PIN_DOWN) == LOW;
+    bool rightNow = digitalRead(BUTTON_PIN_RIGHT) == LOW;
+
+    if (rightNow && !rightPrev) {
+        paused = !paused;
+        needsRedraw = true;
+        delay(200);
+    }
+
+    if (upNow && !upPrev && !paused) {
+        if (autoHop) {
+            autoHop = false;
+        } else {
+            currentChannel++;
+            if (currentChannel > 13) { currentChannel = 1; autoHop = true; }
+            esp_wifi_set_channel(currentChannel, WIFI_SECOND_CHAN_NONE);
+        }
+        needsRedraw = true;
+        delay(200);
+    }
+
+    if (downNow && !downPrev && !paused) {
+        if (autoHop) {
+            autoHop = false;
+        } else {
+            currentChannel--;
+            if (currentChannel < 1) { currentChannel = 13; autoHop = true; }
+            esp_wifi_set_channel(currentChannel, WIFI_SECOND_CHAN_NONE);
+        }
+        needsRedraw = true;
+        delay(200);
+    }
+
+    upPrev = upNow;
+    downPrev = downNow;
+    rightPrev = rightNow;
+
+    if (autoHop && !paused && (now - lastHop >= HOP_INTERVAL)) {
+        lastHop = now;
+        currentChannel++;
+        if (currentChannel > 13) currentChannel = 1;
+        esp_wifi_set_channel(currentChannel, WIFI_SECOND_CHAN_NONE);
+    }
+
+    if (totalPackets != lastDisplayedTotal ||
+        currentChannel != lastDisplayedChannel ||
+        paused != lastPaused) {
+        needsRedraw = true;
+        lastDisplayedTotal = totalPackets;
+        lastDisplayedChannel = currentChannel;
+        lastPaused = paused;
+    }
+
+    if (needsRedraw && (now - lastDraw >= DRAW_INTERVAL)) {
+        needsRedraw = false;
+        lastDraw = now;
+        drawScreen();
+    }
+}


### PR DESCRIPTION
Beacon Spam Fix:
- Replace static 83/109-byte frame templates with dynamic sendBeaconFrame() that builds frames with correct IE tag offsets based on actual SSID length. The old templates had a fixed 32-byte SSID field causing supported rates and DS parameter tags to be at wrong offsets for shorter SSIDs.
- Switch from WIFI_MODE_STA to WIFI_MODE_AP for reliable esp_wifi_80211_tx() on some ESP-IDF versions where STA mode silently drops raw TX frames.
- After clone scan completes, restore WIFI_MODE_AP instead of promiscuous mode.

Packet Logger (new tool):
- Sniffs all WiFi management and data frames in promiscuous mode
- OLED displays rolling log of last 5 packets (type, src MAC, RSSI, length)
- Streams CSV to serial at 115200 baud for real-time capture on a laptop
- Channel hopping (1-13, 500ms) with manual lock via UP/DOWN buttons
- Pause/resume with RIGHT button, shows MGMT/DATA counters when paused
- Respects privacy mode (masks MACs on OLED, full MACs in serial output)